### PR TITLE
Add: ChatRoom 페이지 화면 구현 및 라우팅 연결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
           <Route path="/profile" element={<CommonLayout page={'profile'} />} />
           <Route path="/search" element={<CommonLayout page={'search'} />} />
           <Route path="/chatList" element={<CommonLayout page={'chatList'} />} />
-          <Route path="/chat" element={<CommonLayout page={'chat '} />} />
+          <Route path="/chatRoom" element={<CommonLayout page={'chatRoom'} />} />
         </Routes>
       </StyledContainer>
     </>

--- a/src/components/bottomNavBar/BottomNavBar.jsx
+++ b/src/components/bottomNavBar/BottomNavBar.jsx
@@ -11,7 +11,7 @@ const BottomNavBar = () => {
           </Styled.BottomLink>
         </Styled.BottomLi>
         <Styled.BottomLi>
-          <Styled.BottomLink to="/chat">
+          <Styled.BottomLink to="/chatList">
             <MessageCircleIcon />
             채팅
           </Styled.BottomLink>

--- a/src/layout/commonLayout/CommonLayout.jsx
+++ b/src/layout/commonLayout/CommonLayout.jsx
@@ -6,6 +6,7 @@ import Home from '../../pages/home/home';
 import Profile from '../../pages/profile/Profile';
 import { useEffect, useState } from 'react';
 import Search from '../../pages/search/Search';
+import ChatRoom from '../../pages/chatRoom/ChatRoom';
 
 function Content({ page, searchQuery }) {
   switch (page) {
@@ -17,6 +18,8 @@ function Content({ page, searchQuery }) {
       return <Search searchQuery={searchQuery} />;
     case 'chatList':
       return <ChatList />;
+    case 'chatRoom':
+      return <ChatRoom />;
   }
 }
 
@@ -30,7 +33,7 @@ const CommonLayout = ({ page }) => {
   }, [location.pathname]);
 
   //bottom이 안붙는 케이스엔 여기에 추가
-  const hiddenPaths = ['/post', '/chat'];
+  const hiddenPaths = ['/post', '/chatRoom'];
   return (
     <>
       <Header location={location} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />

--- a/src/pages/chatRoom/ChatInput.jsx
+++ b/src/pages/chatRoom/ChatInput.jsx
@@ -1,0 +1,64 @@
+import { useState, useRef } from 'react';
+import * as Styled from './ChatInput.style.js';
+import { Image } from 'lucide-react';
+
+const ChatInput = ({ onSend }) => {
+  const [message, setMessage] = useState('');
+  const fileInputRef = useRef(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+
+    onSend({type: 'text', content: message});
+    setMessage('');
+  };
+
+  const handleImageUpload = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      alert('이미지 파일만 업로드할 수 있어요!');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (reader.result) {
+        onSend({ type: 'image', image: reader.result });
+      } else {
+        alert('이미지 로드에 실패했어요!');
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+
+  return (
+    <Styled.InputWrapper onSubmit={handleSubmit}>
+      <Styled.ImageButton
+        type="button"
+        onClick={() => fileInputRef.current.click()}
+      >
+        <Image color="#ffffff" size={22}/>
+      </Styled.ImageButton>
+      <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={handleImageUpload}
+      />
+      <Styled.Input
+        type="text"
+        placeholder="메시지를 입력하세요"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+      />
+      <Styled.Button type="submit">전송</Styled.Button>
+    </Styled.InputWrapper>
+  );
+};
+
+export default ChatInput;

--- a/src/pages/chatRoom/ChatInput.style.js
+++ b/src/pages/chatRoom/ChatInput.style.js
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+
+export const InputWrapper = styled.form`
+  position: absolute;
+  height: 61px;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  border-top: 1px solid ${({ theme }) => theme.colors.white400};
+  background-color: ${({ theme }) => theme.colors.white100};
+  z-index: 10;
+`;
+
+export const Input = styled.input`
+  flex: 1;
+  padding: 10px 14px;
+  border: none;
+  border-radius: 20px;
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;
+
+export const Button = styled.button` 
+  margin-left: 8px;
+  background-color: transparent;
+  color: ${({ theme }) => theme.colors.white300};
+  border: none;
+  padding: 0 16px;
+  font-weight: ${({ theme }) => theme.fonts.weights.medium};
+  cursor: pointer;
+
+  transition: color 0.2s ease, color 0.2s ease;
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const ImageButton = styled.button`
+  width: 36px;
+  height: 36px;
+  background-color: ${({ theme }) => theme.colors.white400};
+  display: flex;
+  justify-content: center;
+  align-items: center; 
+  align-self: center;
+  border-radius: 50%;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 8px;
+  color: ${({ theme }) => theme.colors.primary};
+  margin-right: 18px;
+
+
+  transition: background-color 0.2s ease, color 0.2s ease;
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primary};
+  }
+`;

--- a/src/pages/chatRoom/ChatMessage.jsx
+++ b/src/pages/chatRoom/ChatMessage.jsx
@@ -1,0 +1,34 @@
+import * as Styled from './ChatMessage.style.js';
+
+const ChatMessage = ({ data, onImageClick }) => {
+  const { sender, type, content, image, profileImage, createdTime } = data;
+  const isMine = sender === 'me';
+
+   // 시간 포맷 변환
+  const formattedTime = new Date(createdTime).toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  return (
+    <Styled.MessageWrapper $isMine={isMine}>
+       {!isMine && profileImage && (
+        <Styled.ProfileImg src={profileImage} alt="상대 프로필" />
+      )}
+      <Styled.MessageLine $isMine={isMine}>
+        <Styled.MessageBubble $isMine={isMine}>
+          {type === 'text' ? (
+            <span>{content}</span>
+          ) : (
+            <Styled.ImageWrapper onClick={() => onImageClick(image)}>
+              <Styled.StyledImage src={image} alt="chat" />
+            </Styled.ImageWrapper>
+          )}
+        </Styled.MessageBubble>
+        <Styled.TimeText $isMine={isMine}>{formattedTime}</Styled.TimeText>
+      </Styled.MessageLine>
+    </Styled.MessageWrapper>
+  );
+};
+
+export default ChatMessage;

--- a/src/pages/chatRoom/ChatMessage.style.js
+++ b/src/pages/chatRoom/ChatMessage.style.js
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+
+export const MessageWrapper = styled.div`
+  display: flex;
+  justify-content: ${({ $isMine }) => ($isMine ? 'flex-end' : 'flex-start')};
+  margin: 8px 16px;
+`;
+
+export const MessageBubble = styled.div`
+  max-width: 240px;
+  padding: 12px;
+  border-radius: ${({ $isMine }) => ($isMine ? '12px 0px 12px 12px' : '0px 12px 12px 12px')};
+  border: ${({ $isMine, theme }) => 
+    $isMine ? 'none' : `1px solid ${theme.colors.white400}` };
+  background-color: ${({ $isMine, theme }) =>
+    $isMine ? theme.colors.primary : theme.colors.white100};
+  color: ${({ $isMine, theme }) =>
+    $isMine ? theme.colors.white100 : theme.colors.black};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  font-weight: ${({ theme }) => theme.fonts.weights.regular};
+  line-height: 1.4;
+  word-break: break-word;
+
+  img {
+    max-width: 200px;
+    border-radius: 12px;
+    display: block;
+  }
+`;
+
+export const MessageList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  padding-bottom: 80px;
+`;
+
+export const MessageLine = styled.div`
+  display:flex;
+   flex-direction: ${({ $isMine }) => ($isMine ? 'row-reverse' : 'row')}; // ✅ 나일 땐 시간 왼쪽
+`;
+
+export const ProfileImg = styled.img`
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  margin-right: 12px;
+  align-self: flex-start;
+`;
+
+export const TimeText = styled.span`
+  display: block;
+  margin-top: 4px;
+  font-size: ${({ theme }) => theme.fontSize.xSmall};
+  color: ${({ theme }) => theme.colors.white700};
+  text-align: ${({ $isMine }) => ($isMine ? 'right' : 'left')};
+  align-self: flex-end;
+  padding: 0 4px;
+`;
+
+export const ImageWrapper = styled.div`
+  width: 200px;
+  aspect-ratio: 4 / 3; // ✅ 원하는 비율 (1/1, 16/9 등도 가능)
+  overflow: hidden;
+  border-radius: 12px;
+`;
+
+export const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover; // or contain
+  display: block;
+`;

--- a/src/pages/chatRoom/ChatRoom.jsx
+++ b/src/pages/chatRoom/ChatRoom.jsx
@@ -1,0 +1,119 @@
+import * as Styled from './ChatRoom.style.js';
+import { useState, useEffect, useRef } from 'react';
+import ChatMessage from './ChatMessage';
+import ChatInput from './ChatInput';
+import sampleImg from '../../assets/images/sample.png';
+
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+function isDifferentDay(date1, date2) {
+  return new Date(date1).toDateString() !== new Date(date2).toDateString();
+}
+
+const ChatRoom = () => {
+  const [chatMessages, setChatMessages] = useState([]);
+  const messagesEndRef = useRef(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  useEffect(() => {
+    const dummyData = [
+      {
+        id: 1,
+        sender: 'other',
+        type: 'text',
+        content: '샬라카둘라 매지카둘라 비비디바비디부',
+        profileImage: sampleImg,
+        createdTime: '2025-07-31T15:21:00',
+      },
+      {
+        id: 2,
+        sender: 'other',
+        type: 'text',
+        content: '안녕하세요. 감귤 사고싶어요요요요요',
+        profileImage: sampleImg,
+        createdTime: '2025-07-31T15:21:00',
+      },
+      {
+        id: 3,
+        sender: 'me',
+        type: 'text',
+        content: '네 말씀하세요.',
+        profileImage: sampleImg,
+        createdTime: '2025-07-31T15:21:00',
+      },
+      {
+        id: 4,
+        sender: 'me',
+        type: 'image',
+        profileImage: sampleImg,
+        image: sampleImg,
+        createdTime: '2025-07-31T15:21:00',
+      },
+    ];
+    setChatMessages(dummyData);
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [chatMessages]);
+
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  return (
+    <Styled.ChatRoom>
+      <Styled.MessageList>
+        {chatMessages.map((msg, idx) => {
+          const isFirst = idx === 0;
+          const prevMsg = chatMessages[idx - 1];
+          const isNewDay =
+            isFirst || isDifferentDay(msg.createdTime, prevMsg.createdTime);
+
+          return (
+            <div key={msg.id}>
+              {isNewDay && (
+                <Styled.DateDivider>
+                  {formatDate(msg.createdTime)}
+                </Styled.DateDivider>
+              )}
+              <ChatMessage data={msg} onImageClick={setSelectedImage} />
+            </div>
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </Styled.MessageList>
+
+      {selectedImage && (
+        <Styled.ModalOverlay onClick={() => setSelectedImage(null)}>
+          <Styled.ModalImage src={selectedImage} alt="확대 이미지" />
+        </Styled.ModalOverlay>
+      )}
+
+      <ChatInput
+        onSend={(msg) => {
+          const newMessage = {
+            id: Date.now(),
+            sender: 'me',
+            type: msg.type,
+            content: msg.content || '',
+            image: msg.image || null,
+            createdTime: new Date().toISOString(),
+          };
+          setChatMessages((prev) => [...prev, newMessage]);
+        }}
+      />
+    </Styled.ChatRoom>
+  );
+};
+
+export default ChatRoom;

--- a/src/pages/chatRoom/ChatRoom.style.js
+++ b/src/pages/chatRoom/ChatRoom.style.js
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+export const ChatRoom = styled.section`
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px);
+  position: relative;
+  background-color: ${({ theme }) => theme.colors.white200};
+`;
+
+export const MessageList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  padding-bottom: 80px;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const DateDivider = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.white700};
+  font-size: 12px;
+  margin: 20px ;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid #ccc;
+  }
+
+  &::before {
+    margin-right: 10px;
+  }
+
+  &::after {
+    margin-left: 10px;
+  }
+`;
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ModalImage = styled.img`
+  max-width: 80%;
+  max-height: 80%;
+  border-radius: 8px;
+  object-fit: contain;
+`;


### PR DESCRIPTION
### ✨ 작업 개요
- ChatRoom 페이지 화면 구성
- 채팅 메시지 UI 분리 (ChatInput, ChatMessage)
- 이미지 확대 모달 및 스크롤 자동 이동 기능 포함

### 🔧 개발 내용
- `/chatRoom` 라우팅 설정 및 연결
- 메시지 전송 기능 구현 (텍스트 + 이미지)
- styled-components 기반 스타일링 적용
- 하단 메뉴(chat icon) 클릭 시 `/chatList`로 이동되도록 연결